### PR TITLE
초기 로딩 속도 개선, 인티니티 스크롤 적용

### DIFF
--- a/components/Job.tsx
+++ b/components/Job.tsx
@@ -21,7 +21,7 @@ const Jobs = ({
   requirement = applyMultipleBlankToOneBlank(requirement); // 스타일 망가뜨리는 다중 공백 제거
 
   return (
-    <div className="p-5 shadow rounded bg-white mt-3 sm:p-3 sm:m-3">
+    <div className="p-5 shadow rounded bg-white mt-3 sm:p-3 sm:m-3 job-wrapper">
       <h2 className="text-gray-700">
         {" "}
         <HighLight content={companyName} searchText={searchKeyword} />

--- a/hooks/useIntersectionObserver.tsx
+++ b/hooks/useIntersectionObserver.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+export default ({
+  root,
+  target,
+  onIntersect,
+  threshold = 1.0,
+  rootMargin = "0px"
+}) => {
+  useEffect(() => {
+    const observer = new IntersectionObserver(onIntersect, {
+      root,
+      rootMargin,
+      threshold
+    });
+
+    if (!target) {
+      return;
+    }
+
+    observer.observe(target);
+
+    return () => {
+      observer.unobserve(target);
+    };
+  }, [target, root, rootMargin, onIntersect, threshold]);
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,9 +7,10 @@ import Post from "./t/[type]";
 interface Props {
   data: Job[];
   updated: object[];
+  totalCount: number;
 }
 
-const IndexPage = ({ data, updated }: Props) => {
+const IndexPage = ({ data, updated, totalCount }: Props) => {
   let defaultQueryObject = { type: "frontend" };
   const store = useRootData(store => store);
   const { setCurrentPage } = store;
@@ -17,20 +18,29 @@ const IndexPage = ({ data, updated }: Props) => {
 
   return (
     <>
-      <Post query={defaultQueryObject} data={data} updated={updated} />
+      <Post
+        query={defaultQueryObject}
+        data={data}
+        updated={updated}
+        totalCount={totalCount}
+      />
     </>
   );
 };
 
 IndexPage.getInitialProps = async function() {
-  const res = await fetch("https://rbye-api.lastrites.now.sh/frontend");
+  const res = await fetch(
+    "https://rbye-api.lastrites.now.sh/frontend?_page=1&_limit=30"
+  );
   const res2 = await fetch("https://rbye-api.lastrites.now.sh/updated");
   const data: Job[] = await res.json();
   const updated: object[] = await res2.json();
+  const totalCount = Number(res.headers.get("X-Total-Count"));
 
   return {
     data,
-    updated
+    updated,
+    totalCount
   };
 };
 

--- a/pages/t/[type].tsx
+++ b/pages/t/[type].tsx
@@ -8,6 +8,7 @@ import JobList from "../../components/JobList";
 import Layout from "../../components/Layout";
 import NavBar from "../../components/NavBar";
 import { useRootData } from "../../hooks";
+import useIntersectionObserver from "../../hooks/useIntersectionObserver";
 
 interface QueryType {
   type: string;
@@ -17,12 +18,18 @@ interface Props {
   data: Job[];
   updated: object[];
   query?: QueryType;
-  // year?: number;
+  totalCount?: number;
 }
 
 export default function Post(props: Props) {
   const [data, setData] = React.useState(props.data || []);
   const [isFirstLoading, setIsFirstLoading] = React.useState(true);
+  const [loading, setLoading] = React.useState(false);
+
+  const currentPage = React.useRef(1);
+  const totalPage = React.useRef(1);
+  const rootRef = React.useRef(null);
+  const targetRef = React.useRef(null);
 
   const store = useRootData(store => store);
   const year = useRootData(store => store.year.get());
@@ -35,63 +42,101 @@ export default function Post(props: Props) {
   const setCurrentCategory = currentCategory =>
     store.setCurrentCategory(currentCategory);
 
-  if (
-    !Array.isArray(props.data) ||
-    props.data.length === 0 ||
-    !props.query?.type
-  ) {
-    return (
-      <Layout title="데이터 오류 | RBYE.NOW.SH">
-        <div className="text-center text-teal-500 text-xl">
-          이런, 데이터를 찾을 수가 없습니다. 정확한 경로인지 확인해주세요.
-        </div>
-      </Layout>
+  const lastChildBefore = () =>
+    document.querySelector(".job-wrapper:nth-last-child(2)");
+
+  React.useEffect(() => {
+    const maxPage = (props.totalCount && props.totalCount / 30) || 1;
+    if (props.totalCount) totalPage.current = Number(maxPage.toFixed(0));
+  }, []);
+
+  const loadMoreData = React.useCallback(async () => {
+    setLoading(true);
+    currentPage.current++;
+    const res = await fetch(
+      `https://rbye-api.now.sh/${props.query?.type}?_page=${currentPage.current}&_limit=30`
     );
-  }
+
+    const newData = await res.json();
+    setData([...data, ...newData]);
+    setLoading(false);
+  }, [data]);
+
+  const getData = React.useCallback(
+    async (
+      requestLink = `https://rbye-api.now.sh/${props.query?.type}?contentObj.requirement_like=${year}년`
+    ) => {
+      setLoading(true);
+      const res = await fetch(requestLink);
+      let newData = await res.json();
+
+      if (currentCategory === "제한없음") {
+        newData = newData.filter(
+          item =>
+            item.contentObj.requirement &&
+            !item.contentObj.requirement.includes("년")
+        );
+      }
+
+      setData(newData);
+      setLoading(false);
+    },
+    [data, year]
+  );
+
+  useIntersectionObserver({
+    root: rootRef.current,
+    target: targetRef.current,
+    onIntersect: async (entries, observer) => {
+      const intersectionObserverEntry = entries.pop();
+      const isIntersecting = intersectionObserverEntry.isIntersecting;
+
+      if (currentCategory !== "전체") {
+        observer.unobserve(intersectionObserverEntry.target);
+      }
+      if (
+        currentCategory === "전체" &&
+        isIntersecting &&
+        !loading &&
+        !searchKeyword &&
+        currentPage.current < totalPage.current
+      ) {
+        await loadMoreData();
+        observer.unobserve(intersectionObserverEntry.target);
+        observer.observe(lastChildBefore());
+      }
+    }
+  });
 
   React.useEffect(() => {
     props.query?.type && store.setCurrentPage(props.query?.type);
   }, []);
 
   React.useEffect(() => {
-    async function getData() {
-      const res = await fetch(
-        `https://rbye-api.now.sh/${props.query?.type}?q=${searchKeyword}`
-      );
-      const newData = await res.json();
-      await setData(newData);
-      await setYear(0);
-    }
     currentCategory !== "햇수" &&
       currentCategory !== "제한없음" &&
       !isFirstLoading &&
-      getData();
+      getData(
+        `https://rbye-api.now.sh/${props.query?.type}?q=${searchKeyword}`
+      );
   }, [searchKeyword]);
 
   React.useEffect(() => {
-    async function getData() {
-      const res = await fetch(
-        `https://rbye-api.now.sh/${props.query?.type}?contentObj.requirement_like=${year}년`
-      );
-      const newData = await res.json();
-      await setData(newData);
-    }
-
     if (currentCategory === "전체") {
+      console.log("전체 call?");
       return setData(props.data);
     }
 
     if (currentCategory === "제한없음") {
-      return setData(
-        props.data.filter(
-          item =>
-            item.contentObj.requirement &&
-            !item.contentObj.requirement.includes("년")
-        )
-      );
+      getData(`https://rbye-api.lastrites.now.sh/${props.query?.type}`);
+      return;
     }
 
-    if (year > 0 && currentCategory !== "신입") {
+    if (
+      year > 0 &&
+      currentCategory !== "신입" &&
+      currentCategory !== "제한없음"
+    ) {
       getData();
     }
   }, [year, currentCategory]);
@@ -123,15 +168,18 @@ export default function Post(props: Props) {
     return temp;
   };
 
-  let dataLength: number = 0;
   if (
-    (year && data.length) ||
-    searchKeyword ||
-    currentCategory === "제한없음"
+    !Array.isArray(props.data) ||
+    props.data.length === 0 ||
+    !props.query?.type
   ) {
-    dataLength = data.length;
-  } else if (!year) {
-    dataLength = props.data && props.data.length;
+    return (
+      <Layout title="데이터 오류 | RBYE.NOW.SH">
+        <div className="text-center text-teal-500 text-xl">
+          이런, 데이터를 찾을 수가 없습니다. 정확한 경로인지 확인해주세요.
+        </div>
+      </Layout>
+    );
   }
 
   return (
@@ -141,6 +189,7 @@ export default function Post(props: Props) {
         <div className="flex flex-wrap justify-between">
           <div className="flex flex-wrap cursor-pointer">
             {displayYear()}
+
             <span
               className={
                 currentCategory === "제한없음"
@@ -176,6 +225,7 @@ export default function Post(props: Props) {
                   : "m-1 hover:text-gray-500"
               }
               onClick={() => {
+                setYear(0);
                 setCurrentCategory("전체");
                 setSearchKeyword("");
               }}
@@ -184,7 +234,9 @@ export default function Post(props: Props) {
             </span>
           </div>
           <span className="text-gray-500 text-sm">
-            데이터 수 {dataLength} 데이터 업데이트{" "}
+            데이터 수{" "}
+            {currentCategory === "전체" ? props.totalCount : data.length} 데이터
+            업데이트
             {props.updated[0]?.[props.query.type] &&
               formatDistanceToNow(
                 parse(
@@ -202,21 +254,32 @@ export default function Post(props: Props) {
             </span>
           </span>
         </div>
-        <JobList data={data} searchKeyword={searchKeyword} />
+        <div>
+          <JobList data={data} searchKeyword={searchKeyword} />
+          {searchKeyword && data.length === 0 && !loading && (
+            <div className="text-center text-teal-500 text-xl">
+              {searchKeyword} 키워드와 일치하는 데이터가 없습니다.
+            </div>
+          )}
+        </div>
       </div>
     </Layout>
   );
 }
 
 Post.getInitialProps = async function({ query }) {
-  const res = await fetch(`https://rbye-api.lastrites.now.sh/${query.type}`);
+  const res = await fetch(`https://rbye-api.lastrites.now.sh/${query.type}?_page=1&_limit=30
+  `);
   const res2 = await fetch("https://rbye-api.lastrites.now.sh/updated");
   const data: Job[] = await res.json();
   const updated: object[] = await res2.json();
 
+  const totalCount = Number(res.headers.get("X-Total-Count"));
+
   return {
     data,
     updated,
-    query
+    query,
+    totalCount
   };
 };


### PR DESCRIPTION
초기 로딩 속도를 개선하기 위해 접속시 가져오는 데이터를 줄이고, IntersectionObserver를 사용해서 인피니티 스크롤을 적용하라

- 그외에 전체와 년도가 같이 선택이 되던 문제 수정